### PR TITLE
increased specificity of css selector in login.css

### DIFF
--- a/client/src/Pages/css/login.css
+++ b/client/src/Pages/css/login.css
@@ -147,7 +147,7 @@
 }
 
 .form input[type="text"],
-input[type="password"] {
+.form input[type="password"] {
     width: 100%;
     border-style: none;
     font-family: inherit;
@@ -166,7 +166,7 @@ input[type="password"] {
 }
 
 .form input[type="text"]:focus,
-input[type="password"]:focus {
+.form input[type="password"]:focus {
     outline: none;
 }
 


### PR DESCRIPTION
Password input of Add/Edit User pages was inheriting CSS from login.css 
![image](https://user-images.githubusercontent.com/61008054/135960996-5e850b58-87a3-4613-a046-24f6c4354379.png)

Changes resolve this issue on AdminAddUser.js and AdminEditUser.js